### PR TITLE
Added Toast with message to inform user of aborting the generation of…

### DIFF
--- a/app/src/main/java/com/fido/example/fidoapiexample/U2FDemoActivity.java
+++ b/app/src/main/java/com/fido/example/fidoapiexample/U2FDemoActivity.java
@@ -342,6 +342,15 @@ public class U2FDemoActivity extends AppCompatActivity
         if (ContextCompat.checkSelfPermission(this, Manifest.permission.GET_ACCOUNTS)
                 == PackageManager.PERMISSION_GRANTED) {
             Log.i(TAG, "getSignRequest permission is granted");
+            if (securityTokens.isEmpty()) {
+                Toast.makeText(
+                        U2FDemoActivity.this,
+                        "No token present",
+                        Toast.LENGTH_SHORT)
+                        .show();
+                Log.w(TAG, "No token present. Aborting Sign Request generation.");
+                return;
+            }
             Task<SignRequestParams> getSignRequestTask = asyncGetSignRequest();
             getSignRequestTask.addOnCompleteListener(new OnCompleteListener<SignRequestParams>() {
                 @Override


### PR DESCRIPTION
… sign request when no tokens are present.

Solves a bug when the app used to crash when you pressed "Authenticate token" with no tokens registered.